### PR TITLE
Fix the serde + wasmbingen deprecation warning

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -522,6 +522,7 @@ dependencies = [
  "console_error_panic_hook",
  "console_log",
  "flux",
+ "gloo-utils",
  "glow",
  "js-sys",
  "log",
@@ -595,6 +596,19 @@ dependencies = [
  "khronos_api",
  "log",
  "xml-rs",
+]
+
+[[package]]
+name = "gloo-utils"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8e8fc851e9c7b9852508bc6e3f690f452f474417e8545ec9857b7f7377036b5"
+dependencies = [
+ "js-sys",
+ "serde",
+ "serde_json",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]
@@ -1657,8 +1671,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eaf9f5aceeec8be17c128b2e93e031fb8a4d469bb9c4ae2d7dc1888b26887268"
 dependencies = [
  "cfg-if 1.0.0",
- "serde",
- "serde_json",
  "wasm-bindgen-macro",
 ]
 

--- a/flux-wasm/Cargo.toml
+++ b/flux-wasm/Cargo.toml
@@ -22,7 +22,8 @@ glow = "0.11.2"
 js-sys = "0.3"
 log = "0.4"
 serde = { version = "1", features = ["derive"] }
-wasm-bindgen = { version = "=0.2.83", features = ["serde-serialize"] }
+gloo-utils = { version = "0.1", features = ["serde"] }
+wasm-bindgen = { version = "=0.2.83" }
 
 [dependencies.web-sys]
 version = "0.3"

--- a/flux-wasm/src/wasm_wrapper.rs
+++ b/flux-wasm/src/wasm_wrapper.rs
@@ -1,4 +1,5 @@
 use flux::{self, settings};
+use gloo_utils::format::JsValueSerdeExt;
 use serde::Serialize;
 use std::rc::Rc;
 use wasm_bindgen::prelude::*;


### PR DESCRIPTION
Serialization support has been removed from wasmbingen and extracted into a separate library. There's a new marshalling library available that communicates through JS, but I'm just going to stick to the JSON method.